### PR TITLE
Make status.json a CNAB Output

### DIFF
--- a/804-well-known-custom-actions.md
+++ b/804-well-known-custom-actions.md
@@ -11,8 +11,7 @@ A CNAB indicates that it supports those actions by including them in its custom 
 - `io.cnab.dry-run` (with `stateless`: true and `modifies`: false): execute the installation in a dry-run mode, allowing to see what would happen with the given set of parameter values.
 - `io.cnab.help` (with `stateless`: true and `modifies`: false): print an help message to the standard output. Implementations MAY print different messages depending on the parameters values passed to the invocation image.
 - `io.cnab.log` (with `stateless`: false and `modifies`: false): print logs of the installed system to the standard output.
-- `io.cnab.status` (with `stateless`: false and `modifies`: false): print a human readable status message to the standard output.
-- `io.cnab.status+json` (with `stateless`: false and `modifies`: false): print a json payload describing the detailed status as in the example below ([here](schema/status.schema.json) is the JSON schema for this):
+- `io.cnab.status` (with `stateless`: false and `modifies`: false): print a human readable status message to the standard output. This action also produces an output file named `status` describing the detailed status as in the example below ([here](schema/status.schema.json) is the JSON schema for this):
 	```json
     {
       "components": {


### PR DESCRIPTION
As per https://github.com/deislabs/cnab-go/pull/154/files#r340791888, it seems like there should be no need for a separate `io.cnab.status+json` action when `io.cnab.status` also exists given that `io.cnab.status` could define a cnab output for the `status.json` file.