### PR TITLE
fix: formalize the field definitions on the Claims spec.

### DIFF
--- a/103-bundle-runtime.md
+++ b/103-bundle-runtime.md
@@ -30,7 +30,7 @@ The bundle definition is made accessible from inside the invocation image in ord
 CNAB allows injecting data into the invocation image in two ways:
 
 - Environment Variables: This is the preferred method. In this method, data is encoded as a string and placed into the the environment with an associated name.
-- Files: Additional files MAY be injected _at known points_ into the invocation image. In the current specification, only credentials MAY be injected this way.
+- Files: Additional files MAY be injected _at known points_ into the invocation image via credentials or parameters.
 
 The spec does not define or constrain any network interactions between the invocation image and external services or sources.
 

--- a/400-claims.md
+++ b/400-claims.md
@@ -18,22 +18,6 @@ The claims system is designed to satisfy the requirements of the [Bundle Runtime
 
 This specification uses the terminology defined in [the CNAB Core specification](100-CNAB.md).
 
-## Concepts of Package Management
-
-A _package_ is a discrete data chunk that can be moved from location to location, and can be unpacked and installed onto a system. Typically, a package contains an application or application description. All package managers provide some explicit definition of a package and a package format.
-
-When a package is installed, the contents of a package are extracted and placed into the appropriate spaces on the target system, thus becoming an _installation_ (or _instance_) of the package.
-
-There are three core feature categories of a package manager system:
-
-- It can _install_ packages (initially put something onto a system)
-- It can _query_ installations (to see what is installed)
-- It can _upgrade_ and _delete_ packages (in other words, it can perform additional mutations on an existing installation)
-
-Package managers provide a wealth of other features, but the above are standard across all package managers. (For example, most package managers also provide a way to query what packages are available for installation.)
-
-This specification explains how CNAB records are generated such that continuity can be established across applications. In other words, this describes how CNAB bundles can be treated analogously to traditional packages.
-
 ## Managing State
 
 Fundamentally, package managers provide a state management layer to keep records of what was installed. For example, [homebrew](http://homebrew.sh), a popular macOS package manager, stores records for all installed software in `/usr/local/Cellar`. Helm, the package manager for Kubernetes, stores state records in Kubernetes ConfigMaps located in the system namespace. The Debian Apt system stores state in `/var/run`. In all of these cases, the stored state allows the package managing system to be able to answer (quickly) the question of whether a given package is installed.

--- a/400-claims.md
+++ b/400-claims.md
@@ -74,46 +74,6 @@ The CNAB claim is defined as a JSON document. The specification currently does n
 ```
 Source: [400.01-claim.json](examples/400.01-claim.json)
 
-<<<<<<< HEAD
-- bundle: The bundle, as defined in [the Bundle Definition](101-bundle-json.md).
-- bundleReference (OPTIONAL): A canonical reference to the bundle used in the last action. This bundle reference SHOULD be digested to identify a specific version of the referenced bundle.
-- created: A timestamp indicating when this release claim was first created. This MUST not be changed after initial creation.
-- custom: A section for custom extension data applicable to a given runtime.
-- modified: A timestamp indicating the last time this release claim was modified.
-- name: The name of the _installation_. This can be automatically generated, though humans may need to interact with it. It MUST be unique within the installation environment, though that constraint MUST be imposed externally. Elsewhere, this field is referenced as the _installation name_.
-- outputs: Key/value pairs that were created by the operation. These are stored so that the user can access them after the operation completes. Some implementations MAY choose not to store these for security or portability reasons.
-- parameters: Key/value pairs that were passed in during the operation. These are stored so that the operation can be re-run. Some implementations MAY choose not to store these for security or portability reasons.
-- result: The outcome of the bundle's last action (e.g. if action is install, this indicates the outcome of the installation.). It is an object with the following fields:
-  - action: Indicates the action that the current bundle is in. This may be any of the built-in actions (`install`, `upgrade`, `uninstall`) as well as any custom actions as defined in the bundle descriptor. The special name `unknown` MAY be used in the case where the CNAB Runtime cannot determine the action name of a claim.
-  - message: A human-readable string that communicates the outcome. Error messages MAY be included in `failure` conditions.
-  - status: Indicates the status of the last phase transition. Valid statuses are:
-    - failure: failed before completion
-    - underway: in progress. This should only be used if the invocation container MUST exit before it can determine whether all operations are complete. Note that `underway` is a _long term status_ that indicates that the installation's final state cannot be determined by the system. For this reason, it should be avoided.
-    - unknown: the state is unknown. This is an error condition.
-    - success: completed successfully
-- revision: An [ULID](https://github.com/ulid/spec) that MUST change each time the release is modified.
-
-> Note that credential data is _never_ stored in a claim. For this reason, a claim is not considered _trivially repeatable_. Credentials MUST be supplied on each action.
-||||||| merged common ancestors
-- bundle: The bundle, as defined in [the Bundle Definition](101-bundle-json.md).
-- created: A timestamp indicating when this release claim was first created. This MUST not be changed after initial creation.
-- custom: A section for custom extension data applicable to a given runtime.
-- modified: A timestamp indicating the last time this release claim was modified.
-- name: The name of the _installation_. This can be automatically generated, though humans may need to interact with it. It MUST be unique within the installation environment, though that constraint MUST be imposed externally. Elsewhere, this field is referenced as the _installation name_.
-- outputs: Key/value pairs that were created by the operation. These are stored so that the user can access them after the operation completes. Some implementations MAY choose not to store these for security or portability reasons.
-- parameters: Key/value pairs that were passed in during the operation. These are stored so that the operation can be re-run. Some implementations MAY choose not to store these for security or portability reasons.
-- result: The outcome of the bundle's last action (e.g. if action is install, this indicates the outcome of the installation.). It is an object with the following fields:
-  - action: Indicates the action that the current bundle is in. This may be any of the built-in actions (`install`, `upgrade`, `uninstall`) as well as any custom actions as defined in the bundle descriptor. The special name `unknown` MAY be used in the case where the CNAB Runtime cannot determine the action name of a claim.
-  - message: A human-readable string that communicates the outcome. Error messages MAY be included in `failure` conditions.
-  - status: Indicates the status of the last phase transition. Valid statuses are:
-    - failure: failed before completion
-    - underway: in progress. This should only be used if the invocation container MUST exit before it can determine whether all operations are complete. Note that `underway` is a _long term status_ that indicates that the installation's final state cannot be determined by the system. For this reason, it should be avoided.
-    - unknown: the state is unknown. This is an error condition.
-    - success: completed successfully
-- revision: An [ULID](https://github.com/ulid/spec) that MUST change each time the release is modified.
-
-> Note that credential data is _never_ stored in a claim. For this reason, a claim is not considered _trivially repeatable_. Credentials MUST be supplied on each action.
-=======
 The fields above are defined as follows:
 
 - `bundle` (REQUIRED): The bundle, as defined in [the Bundle Definition](101-bundle-json.md).
@@ -134,7 +94,6 @@ The fields above are defined as follows:
 - `revision` (REQUIRED): An [ULID](https://github.com/ulid/spec) that MUST change each time the release is modified.
 
 > Note that credential data is _never_ stored in a claim. For this reason, a claim is not considered _trivially repeatable_. Credentials MUST be supplied on each action. Implementations of the claims specification are expected to retrieve the credential requirements from the `bundle` field.
->>>>>>> fix: formalize the field definitions on the Claims spec.
 
 Timestamps in JSON are defined in the [ECMAScript specification](https://www.ecma-international.org/ecma-262/9.0/index.html#sec-date-time-string-format), which matches the [ISO-8601 Extended Format](https://www.iso.org/iso-8601-date-and-time-format.html).
 
@@ -216,15 +175,9 @@ Below, you can see an example of a claim for a bundle that included a single out
 }
 ```
 
-<<<<<<< HEAD
-### How the Claim is Used
-||||||| merged common ancestors
-### How is the Claim Used
-=======
 It is recommended, but not required, that all outputs are saved. However, security-sensitive details may be omitted if the implementation deems this desirable.
 
-### How is the Claim Used
->>>>>>> fix: formalize the field definitions on the Claims spec.
+### How the Claim is Used
 
 The claim is used to inform any CNAB tooling about how to address a particular installation. For example, given the claim record, a package manager that implements CNAB should be able to:
 

--- a/400-claims.md
+++ b/400-claims.md
@@ -59,6 +59,7 @@ The CNAB claim is defined as a JSON document. The specification currently does n
     "schemaVersion": "v1.0.0",
     "version": "0.1.0"
   },
+  "bundleReference": "hub.example.com/my/bundle@sha256:eeeeeeeee...",
   "created": "2018-08-30T20:39:55.549002887-06:00",
   "custom": {},
   "modified": "2018-08-30T20:39:59.611068556-06:00",
@@ -76,6 +77,7 @@ The CNAB claim is defined as a JSON document. The specification currently does n
 Source: [400.01-claim.json](examples/400.01-claim.json)
 
 - bundle: The bundle, as defined in [the Bundle Definition](101-bundle-json.md).
+- bundleReference (OPTIONAL): A canonical reference to the bundle used in the last action. This bundle reference SHOULD be digested to identify a specific version of the referenced bundle.
 - created: A timestamp indicating when this release claim was first created. This MUST not be changed after initial creation.
 - custom: A section for custom extension data applicable to a given runtime.
 - modified: A timestamp indicating the last time this release claim was modified.

--- a/400-claims.md
+++ b/400-claims.md
@@ -34,13 +34,11 @@ From: https://github.com/Homebrew/homebrew-core/blob/master/Formula/cscope.rb
 
 The CNAB Claims specification does not define where or how records are stored, nor how these records MAY be used by CNAB tooling. However, this specification describes how a CNAB-based system MUST emit the record to an invocation image, and provides some guidance on maintaining integrity of the system.
 
-This is done so that implementors can standardize on a way of relating a release claim (the record of a release) to release operations like `install`, `upgrade`, or `uninstall`. This, in turn, is necessary if CNAB bundles are expected to be executable by different implementations.
+This is done so that implementors can standardize on a way of relating a release claim (the record of a release) to release actions like `install`, `upgrade`, or `uninstall`. This, in turn, is necessary if CNAB bundles are expected to be executable by different implementations. If CNAB runtimes implement this common claims system, then tools can share responsibility for managing CNAB applications. For example, one tool may perform actions, while another may provide a visualization dashboard.
 
 ### Anatomy of a Claim
 
-While implementors are not REQUIRED to implement claims, this is the standard format for claims-supporting systems.
-
-The CNAB claim is defined as a JSON document. The specification currently does not require that claims be formatted as Canonical JSON.
+The CNAB claim is defined as a JSON document. The specification currently does not require that claims be formatted as Canonical JSON. However, encoding a claim as Canonical JSON can be done without altering compliance with the present specification.
 
 ```json
 {
@@ -76,6 +74,7 @@ The CNAB claim is defined as a JSON document. The specification currently does n
 ```
 Source: [400.01-claim.json](examples/400.01-claim.json)
 
+<<<<<<< HEAD
 - bundle: The bundle, as defined in [the Bundle Definition](101-bundle-json.md).
 - bundleReference (OPTIONAL): A canonical reference to the bundle used in the last action. This bundle reference SHOULD be digested to identify a specific version of the referenced bundle.
 - created: A timestamp indicating when this release claim was first created. This MUST not be changed after initial creation.
@@ -95,6 +94,47 @@ Source: [400.01-claim.json](examples/400.01-claim.json)
 - revision: An [ULID](https://github.com/ulid/spec) that MUST change each time the release is modified.
 
 > Note that credential data is _never_ stored in a claim. For this reason, a claim is not considered _trivially repeatable_. Credentials MUST be supplied on each action.
+||||||| merged common ancestors
+- bundle: The bundle, as defined in [the Bundle Definition](101-bundle-json.md).
+- created: A timestamp indicating when this release claim was first created. This MUST not be changed after initial creation.
+- custom: A section for custom extension data applicable to a given runtime.
+- modified: A timestamp indicating the last time this release claim was modified.
+- name: The name of the _installation_. This can be automatically generated, though humans may need to interact with it. It MUST be unique within the installation environment, though that constraint MUST be imposed externally. Elsewhere, this field is referenced as the _installation name_.
+- outputs: Key/value pairs that were created by the operation. These are stored so that the user can access them after the operation completes. Some implementations MAY choose not to store these for security or portability reasons.
+- parameters: Key/value pairs that were passed in during the operation. These are stored so that the operation can be re-run. Some implementations MAY choose not to store these for security or portability reasons.
+- result: The outcome of the bundle's last action (e.g. if action is install, this indicates the outcome of the installation.). It is an object with the following fields:
+  - action: Indicates the action that the current bundle is in. This may be any of the built-in actions (`install`, `upgrade`, `uninstall`) as well as any custom actions as defined in the bundle descriptor. The special name `unknown` MAY be used in the case where the CNAB Runtime cannot determine the action name of a claim.
+  - message: A human-readable string that communicates the outcome. Error messages MAY be included in `failure` conditions.
+  - status: Indicates the status of the last phase transition. Valid statuses are:
+    - failure: failed before completion
+    - underway: in progress. This should only be used if the invocation container MUST exit before it can determine whether all operations are complete. Note that `underway` is a _long term status_ that indicates that the installation's final state cannot be determined by the system. For this reason, it should be avoided.
+    - unknown: the state is unknown. This is an error condition.
+    - success: completed successfully
+- revision: An [ULID](https://github.com/ulid/spec) that MUST change each time the release is modified.
+
+> Note that credential data is _never_ stored in a claim. For this reason, a claim is not considered _trivially repeatable_. Credentials MUST be supplied on each action.
+=======
+The fields above are defined as follows:
+
+- `bundle` (REQUIRED): The bundle, as defined in [the Bundle Definition](101-bundle-json.md).
+- `created` (OPTIONAL): A timestamp indicating when this release claim was first created. This MUST not be changed after initial creation.
+- `custom` (OPTIONAL): A section for custom extension data applicable to a given runtime.
+- `modified` (OPTIONAL): A timestamp indicating the last time this release claim was modified. The installation operation MAY set this to a timestamp that matches `created`. Any operation that changes the release SHOULD set this field to the time of the operation.
+- `name` (REQUIRED): The name of the _installation_. This can be automatically generated, though humans may need to interact with it. It MUST be unique within the installation environment, though that constraint MUST be imposed externally. Elsewhere, this field is referenced as the _installation name_. The format of this field must follow the same format used for the `name` field in the [bundle.json file specification](101-bundle-json.md#the-bundlejson-file).
+- `outputs` (OPTIONAL): Key/value pairs that were created by the operation. These are stored so that the user can access them after the operation completes. Some implementations MAY choose not to store these for security or portability reasons. See the [Outputs](#outputs) section for details. If this field is not present, it may be assumed that no outputs were generated as a result of the operation.
+- `parameters` (OPTIONAL): Key/value pairs that were passed in during the operation. These are stored so that the operation can be re-run. Some implementations MAY choose not to store these for security or portability reasons. However, there are some caveats. See the [Parameters](#parameters) section below for details.
+- `result` (REQUIRED): The outcome of the bundle's last action (e.g. if action is install, this indicates the outcome of the installation.). It is an object with the following fields:
+  - `action` (REQUIRED): Indicates the action that the current bundle is in. This may be any of the built-in actions (`install`, `upgrade`, `uninstall`) as well as any custom actions as defined in the bundle descriptor. The special name `unknown` MAY be used in the case where the CNAB Runtime cannot determine the action name of a claim.
+  - `message` (OPTIONAL): A human-readable string that communicates the outcome. Error messages MAY be included in `failure` conditions.
+  - `status` (REQUIRED): Indicates the status of the last phase transition. Valid statuses are:
+    - `failure`: failed before completion
+    - `underway`: in progress. This should only be used if the invocation container MUST exit before it can determine whether all operations are complete. Note that `underway` is a _long term status_ that indicates that the installation's final state cannot be determined by the system. For this reason, it should be avoided.
+    - `unknown`: the state is unknown. This is an error condition.
+    - `success`: completed successfully
+- `revision` (REQUIRED): An [ULID](https://github.com/ulid/spec) that MUST change each time the release is modified.
+
+> Note that credential data is _never_ stored in a claim. For this reason, a claim is not considered _trivially repeatable_. Credentials MUST be supplied on each action. Implementations of the claims specification are expected to retrieve the credential requirements from the `bundle` field.
+>>>>>>> fix: formalize the field definitions on the Claims spec.
 
 Timestamps in JSON are defined in the [ECMAScript specification](https://www.ecma-international.org/ecma-262/9.0/index.html#sec-date-time-string-format), which matches the [ISO-8601 Extended Format](https://www.iso.org/iso-8601-date-and-time-format.html).
 
@@ -115,6 +155,8 @@ The parameter data stored in a claim data is _the resolved key/value pairs_ that
 - The output of this operation is a set of key/value pairs in which:
   - Valid user-supplied values are presented
   - Default values are supplied for all parameters where `default` is provided and no user-supplied value overrides this
+
+It is both optional and discretionary to provide values here. However, if no parameters are supplied, an implementation of this specification is free to interpret this absence as meaning that no parameters were provided during the named action.
 
 ### Outputs
 
@@ -174,7 +216,15 @@ Below, you can see an example of a claim for a bundle that included a single out
 }
 ```
 
+<<<<<<< HEAD
 ### How the Claim is Used
+||||||| merged common ancestors
+### How is the Claim Used
+=======
+It is recommended, but not required, that all outputs are saved. However, security-sensitive details may be omitted if the implementation deems this desirable.
+
+### How is the Claim Used
+>>>>>>> fix: formalize the field definitions on the Claims spec.
 
 The claim is used to inform any CNAB tooling about how to address a particular installation. For example, given the claim record, a package manager that implements CNAB should be able to:
 

--- a/400-claims.md
+++ b/400-claims.md
@@ -174,7 +174,7 @@ Below, you can see an example of a claim for a bundle that included a single out
 }
 ```
 
-### How is the Claim Used
+### How the Claim is Used
 
 The claim is used to inform any CNAB tooling about how to address a particular installation. For example, given the claim record, a package manager that implements CNAB should be able to:
 
@@ -195,6 +195,8 @@ To satisfy these requirements, implementations of a CNAB package manager are exp
 
 Compliant CNAB implementations MUST conform to this section.
 
+### Environment Variables
+
 The claim is produced outside of the CNAB package. The following claim data is injected
 into the invocation container at runtime:
 
@@ -202,10 +204,19 @@ into the invocation container at runtime:
 - `$CNAB_BUNDLE_NAME`: The name of the present bundle.
 - `$CNAB_ACTION`: The action to be performed (install, upgrade, ...)
 - `$CNAB_REVISION`: The ULID for the present release revision. (On upgrade, this is the _new_ revision)
+- `$CNAB_CLAIMS_VERSION`: The version of this specification (currently `CNAB-Claims-1.0-WD`)
 
 > Credential data, which is also injected into the invocation image, is _not_ managed by the claim system. Rules for injecting credentials are found in [the bundle runtime definition](103-bundle-runtime.md).
 
 Parameters declared with an `env` key in the `destination` object MUST have their values injected as environment variables according to the name specified. Likewise, files MUST be injected if `path` is set on `destination`.
+
+### Files
+
+The invocation image may benefit from accessing the claim. Consequently, a claim MUST be attached to the invocation image when the invocation image is started.
+
+The claim MUST be mounted at the path `/cnab/claim.json` inside of the bundle. The version of this claim that is to be mounted is the _version prior to this operation beginning_. In other words, when a bundle is installed, it creates the original installation claim. On the first upgrade, the claim describing the _installation_ is located at `/cnab/claim.json`. This allows the invocation image to inspect the former state and compare it to the desired new state.
+
+Note: Systems may be compliant with the core specification but not support the claims specification. If `$CNAB_CLAIMS_VERSION` is not present, a runtime SHOULD assume that the claims specification is not implemented. Bundle authors may therefore have to take care when relying upon `/cnab/claim.json`, accommodating the case where the runtime does not support claims.
 
 ## Calculating the Result
 

--- a/804-well-known-custom-actions.md
+++ b/804-well-known-custom-actions.md
@@ -84,4 +84,4 @@ A CNAB indicates that it supports those actions by including them in its custom 
     ```
     Source: [804.03-status.json](examples/804.03-status.json)
 
-Next section: [Standardization Process](901-process.md)
+Next section: [Disconnected Scenarios](805-airgap.md)

--- a/804-well-known-custom-actions.md
+++ b/804-well-known-custom-actions.md
@@ -11,8 +11,7 @@ A CNAB indicates that it supports those actions by including them in its custom 
 - `io.cnab.dry-run` (with `stateless`: true and `modifies`: false): execute the installation in a dry-run mode, allowing to see what would happen with the given set of parameter values.
 - `io.cnab.help` (with `stateless`: true and `modifies`: false): print an help message to the standard output. Implementations MAY print different messages depending on the parameters values passed to the invocation image.
 - `io.cnab.log` (with `stateless`: false and `modifies`: false): print logs of the installed system to the standard output.
-- `io.cnab.status` (with `stateless`: false and `modifies`: false): print a human readable status message to the standard output.
-- `io.cnab.status+json` (with `stateless`: false and `modifies`: false): print a json payload describing the detailed status as in the example below ([here](schema/status.schema.json) is the JSON schema for this):
+- `io.cnab.status` (with `stateless`: false and `modifies`: false): print a human readable status message to the standard output. This action also produces an output file named `status` describing the detailed status as in the example below ([here](schema/status.schema.json) is the JSON schema for this):
 	```json
     {
       "components": {

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -10,9 +10,10 @@ Whether you are a user or contributor, official support channels include:
 
 Weekly community meetings are held every Wednesday from 9am-10am PT on zoom. More information can be found on [this agenda document](https://hackmd.io/TfLYtyRnS8Kfx4ekgLwWLg).
 
-## CLA Requirement
-This project welcomes contributions and suggestions. Most contributions require you to agree to a Contributor License Agreement (CLA) declaring that you have the right to, and actually do, grant us the rights to use your contribution. For details, visit https://cla.microsoft.com.
-When you submit a pull request, a CLA-bot will automatically determine whether you need to provide a CLA and decorate the PR appropriately (e.g., label, comment). Simply follow the instructions provided by the bot. You will only need to do this once across all repositories using our CLA.
+## DCO Requirements
+This project welcomes contributions and suggestions. To contribute to the specification, you must sign off every commit you contributed as acknowledgement of the [DCO](https://developercertificate.org/). The repository's DCO bot will check to ensure that every commit is signed, and will block any unsigned commits.
+
+The easiest way to sign-off a commit is to use the Git `--signoff/-s` flag: `git commit -s`.
 
 ## Specifications subject to the Open Web Foundation Agreements.
 In addition, by making a contribution to specifications in this repository, you, on behalf of yourself, your employer, and its affiliates, are making those contributions subject to the obligations set forth in the [OWF Contributor License Agreement 1.0 - Copyright and Patent](http://www.openwebfoundation.org/legal/the-owf-1-0-agreements/owf-contributor-license-agreement-1-0---copyright-and-patent).  


### PR DESCRIPTION
I made an earnest effort to be more specific about the requirements of the various fields on the Claims object.

Signed-off-by: Matt Butcher <matt.butcher@microsoft.com>