### PR TITLE
Add text explaining the DCO requirement.

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -10,9 +10,10 @@ Whether you are a user or contributor, official support channels include:
 
 Weekly community meetings are held every Wednesday from 9am-10am PT on zoom. More information can be found on [this agenda document](https://hackmd.io/TfLYtyRnS8Kfx4ekgLwWLg).
 
-## CLA Requirement
-This project welcomes contributions and suggestions. Most contributions require you to agree to a Contributor License Agreement (CLA) declaring that you have the right to, and actually do, grant us the rights to use your contribution. For details, visit https://cla.microsoft.com.
-When you submit a pull request, a CLA-bot will automatically determine whether you need to provide a CLA and decorate the PR appropriately (e.g., label, comment). Simply follow the instructions provided by the bot. You will only need to do this once across all repositories using our CLA.
+## DCO Requirements
+This project welcomes contributions and suggestions. To contribute to the specification, you must sign off every commit you contributed as acknowledgement of the [DCO](https://developercertificate.org/). The repository's DCO bot will check to ensure that every commit is signed, and will block any unsigned commits.
+
+The easiest way to sign-off a commit is to use the Git `--signoff/-s` flag: `git commit -s`.
 
 ## Specifications subject to the Open Web Foundation Agreements.
 In addition, by making a contribution to specifications in this repository, you, on behalf of yourself, your employer, and its affiliates, are making those contributions subject to the obligations set forth in the [OWF Contributor License Agreement 1.0 - Copyright and Patent](http://www.openwebfoundation.org/legal/the-owf-1-0-agreements/owf-contributor-license-agreement-1-0---copyright-and-patent).  


### PR DESCRIPTION
This replaces the CLA requirement text with an explanation of the DCO.

Closes #306

Signed-off-by: Matt Butcher <matt.butcher@microsoft.com>