### PR TITLE
Add Silvin as core maintainer

### DIFF
--- a/OWNERS
+++ b/OWNERS
@@ -4,3 +4,4 @@ maintainers:
 - technosophos
 - youreddy
 - jeremyrickard
+- silvin-lubecki


### PR DESCRIPTION
As per our discussion during the January 8th meeting ([notes and recording here](https://hackmd.io/s/SyGcBcwQ4#)), this PR adds @silvin-lubecki as core maintainer for the CNAB specification.