### PR TITLE
replaced ambiguous description of environment variable content

### DIFF
--- a/103-bundle-runtime.md
+++ b/103-bundle-runtime.md
@@ -140,11 +140,12 @@ The parameter value is evaluated thus:
 - If the CNAB runtime does not provide a value, but `default` is set, then the default value MUST be used.
 - If the parameter is marked `required` and `default` is set, then the requirement is satisfied by the runtime-provided default.
 - If no value is provided and `default` is unset, the runtime MUST set the value to an empty string (""), regardless of type.
+- When serializing non-string environment variable values, types SHOULD be converted to their [JSON equivalent type](https://www.json.org/json-en.html) and expressed in string format. For example, boolean `true` (or `True` or `TRUE`) SHOULD be expressed as `"true"` and the object `{foo: 23}` SHOULD be expressed as `"{\"foo\": 23}"`.
 - The resolved content of the environment variable SHOULD use UTF-8 character encoding.
 
 > Setting the value of other types to a default value based on type, e.g. Boolean to `false` or integer to `0`, is considered _incorrect behavior_. Setting the value to `null`, `nil`, or a related character string is also considered incorrect.
 
-In the case where the `destination` object has a `path` field, the CNAB runtime MUST create a file at that path. The file MUST have sufficient permissions that the effective user ID of the image can read the contents of the file. the file's character encoding SHOULD be UTF-8 and new lines SHOULD be LF (line feed). And the contents of the file MUST be the parameter value (calculated according to the rules above).
+In the case where the `destination` object has a `path` field, the CNAB runtime MUST create a file at that path. The file MUST have sufficient permissions that the effective user ID of the image can read the contents of the file. The file's character encoding SHOULD be UTF-8 and new lines SHOULD be LF (line feed). And the contents of the file MUST be the parameter value (calculated according to the rules above).
 
 ```json
 {

--- a/103-bundle-runtime.md
+++ b/103-bundle-runtime.md
@@ -140,7 +140,7 @@ The parameter value is evaluated thus:
 - If the CNAB runtime does not provide a value, but `default` is set, then the default value MUST be used.
 - If the parameter is marked `required` and `default` is set, then the requirement is satisfied by the runtime-provided default.
 - If no value is provided and `default` is unset, the runtime MUST set the value to an empty string (""), regardless of type.
-- When serializing non-string environment variable values, types SHOULD be converted to their [JSON equivalent type](https://www.json.org/json-en.html) and expressed in string format. For example, boolean `true` (or `True` or `TRUE`) SHOULD be expressed as `"true"` and the object `{foo: 23}` SHOULD be expressed as `"{\"foo\": 23}"`.
+- Non-string values SHOULD be converted to [JSON text](http://www.ecma-international.org/publications/files/ECMA-ST/ECMA-404.pdf). For example, boolean `true` (or `True` or `TRUE`) SHOULD be expressed as `true` and the object `{foo: 23}` SHOULD be expressed as `{"foo":23}`. String values SHOULD NOT be converted to JSON text.
 - The resolved content of the environment variable SHOULD use UTF-8 character encoding.
 
 > Setting the value of other types to a default value based on type, e.g. Boolean to `false` or integer to `0`, is considered _incorrect behavior_. Setting the value to `null`, `nil`, or a related character string is also considered incorrect.

--- a/103-bundle-runtime.md
+++ b/103-bundle-runtime.md
@@ -140,7 +140,7 @@ The parameter value is evaluated thus:
 - If the CNAB runtime does not provide a value, but `default` is set, then the default value MUST be used.
 - If the parameter is marked `required` and `default` is set, then the requirement is satisfied by the runtime-provided default.
 - If no value is provided and `default` is unset, the runtime MUST set the value to an empty string (""), regardless of type.
-- Non-string values SHOULD be converted to [JSON text](http://www.ecma-international.org/publications/files/ECMA-ST/ECMA-404.pdf). For example, boolean `true` (or `True` or `TRUE`) SHOULD be expressed as `true` and the object `{foo: 23}` SHOULD be expressed as `{"foo":23}`. String values SHOULD NOT be converted to JSON text.
+- Non-string values SHOULD be converted to [JSON text](https://www.ecma-international.org/publications/files/ECMA-ST/ECMA-404.pdf). For example, boolean `true` (or `True` or `TRUE`) SHOULD be expressed as `true` and the object `{foo: 23}` SHOULD be expressed as `{"foo":23}`. String values SHOULD NOT be converted to JSON text.
 - The resolved content of the environment variable SHOULD use UTF-8 character encoding.
 
 > Setting the value of other types to a default value based on type, e.g. Boolean to `false` or integer to `0`, is considered _incorrect behavior_. Setting the value to `null`, `nil`, or a related character string is also considered incorrect.

--- a/103-bundle-runtime.md
+++ b/103-bundle-runtime.md
@@ -140,11 +140,11 @@ The parameter value is evaluated thus:
 - If the CNAB runtime does not provide a value, but `default` is set, then the default value MUST be used.
 - If the parameter is marked `required` and `default` is set, then the requirement is satisfied by the runtime-provided default.
 - If no value is provided and `default` is unset, the runtime MUST set the value to an empty string (""), regardless of type.
-- Values are encoded as JSON strings.
+- The resolved content of the environment variable SHOULD use UTF-8 character encoding.
 
 > Setting the value of other types to a default value based on type, e.g. Boolean to `false` or integer to `0`, is considered _incorrect behavior_. Setting the value to `null`, `nil`, or a related character string is also considered incorrect.
 
-In the case where the `destination` object has a `path` field, the CNAB runtime MUST create a file at that path. The file MUST have sufficient permissions that the effective user ID of the image can read the contents of the file. And the contents of the file MUST be the parameter value (calculated according to the rules above).
+In the case where the `destination` object has a `path` field, the CNAB runtime MUST create a file at that path. The file MUST have sufficient permissions that the effective user ID of the image can read the contents of the file. the file's character encoding SHOULD be UTF-8 and new lines SHOULD be LF (line feed). And the contents of the file MUST be the parameter value (calculated according to the rules above).
 
 ```json
 {


### PR DESCRIPTION
This addresses the root problems in #316, which were about encoding the data inside of env vars. Somehow, we gave the false impression that the body of an env var had to be JSON. I have backed out the text that seemed to imply that.

Note that I have gone with fairly minimal restraints (adopting Chris's SHOULD instead of a MUST) because we need to facilitate some interesting edge cases where a runtime needs to support uncommon character encodings or payload types.

Keep in mind that the author of the bundle.js is presumed to be an expert in the invocation image. So protecting the bundle author from the invocation image (and vice versa) is not a high priority. So this focuses mainly on the relationship between the runtime and the bundle. For a runtime that is tooled to support rare/bespoke operating systems (as we see in IoT), we opt for guidance that allows necessary deviation.

/cc @chris-crone and @corhere

Closes #316 

Signed-off-by: Matt Butcher <matt.butcher@microsoft.com>