### PR TITLE
add 'title' field for custom actions

### DIFF
--- a/101-bundle-json.md
+++ b/101-bundle-json.md
@@ -749,7 +749,7 @@ Implementations MAY support user-defined additional actions as well. Such action
       "stateless": true
     },
     "io.cnab.migrate": {
-      "display": "Migratte",
+      "display": "Migrate",
       "modifies": false
     },
     "io.cnab.status": {

--- a/101-bundle-json.md
+++ b/101-bundle-json.md
@@ -743,14 +743,17 @@ Implementations MAY support user-defined additional actions as well. Such action
 {
   "actions": {
     "io.cnab.dry-run": {
+      "display": "Dry Run",
       "description": "prints what install would do with the given parameters values",
       "modifies": false,
       "stateless": true
     },
     "io.cnab.migrate": {
+      "display": "Migratte",
       "modifies": false
     },
     "io.cnab.status": {
+      "display": "Status",
       "description": "retrieves the status of an installation",
       "modifies": false
     }
@@ -764,6 +767,7 @@ The above declares three actions: `io.cnab.status`, `io.cnab.migrate` and `io.cn
 
 Each action is accompanied by a description, which contains the following fields:
 
+- `display`: The human-readable name of the operation. If omitted, tools MAY use the value of the `actions` key (e.g. `io.cnab.dry-run`). User agents that display the display name SHOULD disambiguate if two or more actions have the same `display` value.
 - `modifies`: Indicates whether the given action will _modify resources_ in any way. If not provided, it will be assumed `false`.
 - `description`: A human readable description of the action (OPTIONAL)
 - `stateless`: The action does not act on a claim, and does not require credentials. This is useful for exposing dry-run actions, printing documentation, etc. (OPTIONAL)

--- a/101-bundle-json.md
+++ b/101-bundle-json.md
@@ -767,7 +767,7 @@ The above declares three actions: `io.cnab.status`, `io.cnab.migrate` and `io.cn
 
 Each action is accompanied by a description, which contains the following fields:
 
-- `title`: The human-readable name of the operation. If omitted, tools MAY use the value of the `actions` key (e.g. `io.cnab.dry-run`). User agents that display the title SHOULD disambiguate if two or more actions have the same `title` value.
+- `title`: The human-readable name of the operation. If omitted, tools MAY use the value of the `actions` key (e.g. `io.cnab.dry-run`). User agents that display the title SHOULD disambiguate if two or more actions have the same `title` value (OPTIONAL).
 - `modifies`: Indicates whether the given action will _modify resources_ in any way. If not provided, it will be assumed `false`.
 - `description`: A human readable description of the action (OPTIONAL)
 - `stateless`: The action does not act on a claim, and does not require credentials. This is useful for exposing dry-run actions, printing documentation, etc. (OPTIONAL)

--- a/101-bundle-json.md
+++ b/101-bundle-json.md
@@ -743,17 +743,17 @@ Implementations MAY support user-defined additional actions as well. Such action
 {
   "actions": {
     "io.cnab.dry-run": {
-      "display": "Dry Run",
+      "title": "Dry Run",
       "description": "prints what install would do with the given parameters values",
       "modifies": false,
       "stateless": true
     },
     "io.cnab.migrate": {
-      "display": "Migrate",
+      "title": "Migrate",
       "modifies": false
     },
     "io.cnab.status": {
-      "display": "Status",
+      "title": "Status",
       "description": "retrieves the status of an installation",
       "modifies": false
     }
@@ -767,7 +767,7 @@ The above declares three actions: `io.cnab.status`, `io.cnab.migrate` and `io.cn
 
 Each action is accompanied by a description, which contains the following fields:
 
-- `display`: The human-readable name of the operation. If omitted, tools MAY use the value of the `actions` key (e.g. `io.cnab.dry-run`). User agents that display the display name SHOULD disambiguate if two or more actions have the same `display` value.
+- `title`: The human-readable name of the operation. If omitted, tools MAY use the value of the `actions` key (e.g. `io.cnab.dry-run`). User agents that display the title SHOULD disambiguate if two or more actions have the same `title` value.
 - `modifies`: Indicates whether the given action will _modify resources_ in any way. If not provided, it will be assumed `false`.
 - `description`: A human readable description of the action (OPTIONAL)
 - `stateless`: The action does not act on a claim, and does not require credentials. This is useful for exposing dry-run actions, printing documentation, etc. (OPTIONAL)

--- a/schema/bundle.schema.json
+++ b/schema/bundle.schema.json
@@ -187,7 +187,7 @@
             "description": "A description of the purpose of this action",
             "type": "string"
           },
-          "display": {
+          "title": {
             "description": "A human-readable name for this action",
             "type": "string"
           },

--- a/schema/bundle.schema.json
+++ b/schema/bundle.schema.json
@@ -188,7 +188,7 @@
             "type": "string"
           },
           "display": {
-            "description": "A human-readable name for thiis action",
+            "description": "A human-readable name for this action",
             "type": "string"
           },
           "modifies": {

--- a/schema/bundle.schema.json
+++ b/schema/bundle.schema.json
@@ -187,6 +187,10 @@
             "description": "A description of the purpose of this action",
             "type": "string"
           },
+          "display": {
+            "description": "A human-readable name for thiis action",
+            "type": "string"
+          },
           "modifies": {
             "description": "Must be set to true if the action can change any resource managed by this bundle",
             "type": "boolean"


### PR DESCRIPTION
Adds a `display` field for custom actions so that a human friendly name can be shown for each custom action.

Closes #242 

Signed-off-by: Matt Butcher <matt.butcher@microsoft.com>