### PR TITLE
ref(bundle.schema.json): remove pattern property from param/cred path

### DIFF
--- a/schema/bundle.schema.json
+++ b/schema/bundle.schema.json
@@ -16,7 +16,6 @@
         },
         "path": {
           "description": "The path inside of the invocation image where credentials will be mounted",
-          "pattern": "^(?!/cnab/app/outputs)/.+$",
           "type": "string"
         },
         "required": {
@@ -159,7 +158,6 @@
             },
             "path": {
               "description": "The path inside of the invocation image where parameter data is mounted",
-              "pattern": "^(?!/cnab/app/outputs)/.+$",
               "type": "string"
             }
           },


### PR DESCRIPTION
Removes the `pattern` property from the definitions for parameters and credentials.

The negative lookup regex used proved problematic for validation (namely, incompatible with golang implementations, of which cnab's most-used - https://github.com/cnabio/cnab-go - is one).

This change would therefore mean implementations are responsible for enforcing spec expectations as regards these path strings, namely, `"Specified path MUST NOT be a subpath of /cnab/app/outputs."` as seen in https://github.com/cnabio/cnab-spec/blob/master/101-bundle-json.md.

Potential solution to https://github.com/cnabio/cnab-spec/issues/215

Corresponding cnab-go implementation: https://github.com/cnabio/cnab-go/pull/180