### PR TITLE
fix(claim.schema.json): s/name/installation in required section

### DIFF
--- a/examples/400.01-claim.json
+++ b/examples/400.01-claim.json
@@ -16,7 +16,7 @@
   "created": "2018-08-30T20:39:55.549002887-06:00",
   "custom": {},
   "modified": "2018-08-30T20:39:59.611068556-06:00",
-  "name": "technosophos.hellohelm",
+  "installation": "technosophos.hellohelm",
   "parameters": {},
   "result": {
     "action": "install",

--- a/schema/claim.schema.json
+++ b/schema/claim.schema.json
@@ -73,7 +73,7 @@
     "bundle",
     "created",
     "modified",
-    "name",
+    "installation",
     "revision"
   ],
   "title": "CNAB Claims json schema",


### PR DESCRIPTION
* Updates the `required` section of the `claim` schema to require `installation` instead of `name` (see https://github.com/cnabio/cnab-spec/pull/310 for genesis of this change)
* Updates example