### PR TITLE
CNAB Core 1.0.1

### DIFF
--- a/000-index.md
+++ b/000-index.md
@@ -5,7 +5,7 @@ weight: 001
 
 # CNAB Specifications
 
-1. [Cloud Native Application Bundle Core 1.0.0 (CNAB1)](100-CNAB.md)
+1. [Cloud Native Application Bundle Core 1.0.1 (CNAB1)](100-CNAB.md)
     - [The bundle.json File](101-bundle-json.md)
     - [The Invocation Image Format](102-invocation-image.md)
     - [The Bundle Runtime](103-bundle-runtime.md)

--- a/100-CNAB.md
+++ b/100-CNAB.md
@@ -3,8 +3,8 @@ title: CNAB Core
 weight: 100
 ---
 
-# Cloud Native Application Bundle Core 1.0.0 (CNAB1)
-*[Final Approval, Published](901-process.md), Sept. 2019*
+# Cloud Native Application Bundle Core 1.0.1 (CNAB1)
+*[Final Approval, Published](901-process.md), Feb. 2020*
 
 
 The Cloud Native Application Bundle (CNAB) is a _standard packaging format_ for multi-component distributed applications. It allows packages to target different runtimes and architectures. It empowers application distributors to package applications for deployment on a wide variety of cloud platforms, providers, and services. Furthermore, it provides necessary capabilities for delivering multi-container applications in disconnected (airgapped) environments.

--- a/101-bundle-json.md
+++ b/101-bundle-json.md
@@ -13,7 +13,7 @@ The `bundle.json` file is a representation of bundle metadata. It MUST be repres
 
 A `bundle.json` is broken down into the following categories of information:
 
-- The schema version of the bundle, as a string with a `v` prefix. This schema is to be referenced as `v1` or `v1.0.0`
+- The schema version of the bundle, as a string with a `v` prefix. This schema is to be referenced as `v1` or `v1.0.1`
 - The top-level package information (`name` and `version`)
   - `name`: The bundle name, including namespacing. The namespace can have one or more elements separated by a dot (e.g. `acme.tunnels.wordpress`). The left most element of the namespace is the most general moving toward more specific elements on the right.
   - `version`: Semantic version of the bundle
@@ -123,7 +123,7 @@ The following is an example of a `bundle.json` for a bundled distributed as a _t
          }
       }
    },
-   "schemaVersion":"v1.0.0",
+   "schemaVersion":"v1.0.1",
    "version":"0.1.2"
 }
 ```
@@ -134,7 +134,7 @@ The canonical JSON version of the above is:
 
 <!-- prettier-ignore -->
 ```json
-{"credentials":{"hostkey":{"env":"HOST_KEY","path":"/etc/hostkey.txt"}},"custom":{"com.example.backup-preferences":{"frequency":"daily"},"com.example.duffle-bag":{"icon":"https://example.com/icon.png","iconType":"PNG"}},"definitions":{"http_port":{"default":80,"maximum":10240,"minimum":10,"type":"integer"},"port":{"maximum":65535,"minimum":1024,"type":"integer"},"string":{"type":"string"},"x509Certificate":{"contentEncoding":"base64","contentMediaType":"application/x-x509-user-cert","type":"string","writeOnly":true}},"description":"An example 'thin' helloworld Cloud-Native Application Bundle","images":{"my-microservice":{"contentDigest":"sha256:aaaaaaaaaaaa...","description":"my microservice","image":"example/microservice:1.2.3"}},"invocationImages":[{"contentDigest":"sha256:aaaaaaa...","image":"example/helloworld:0.1.0","imageType":"docker"}],"maintainers":[{"email":"matt.butcher@microsoft.com","name":"Matt Butcher","url":"https://example.com"}],"name":"helloworld","outputs":{"clientCert":{"definition":"x509Certificate","path":"/cnab/app/outputs/clientCert"},"hostName":{"applyTo":["install"],"definition":"string","description":"the hostname produced installing the bundle","path":"/cnab/app/outputs/hostname"},"port":{"definition":"port","path":"/cnab/app/outputs/port"}},"parameters":{"backend_port":{"definition":"http_port","description":"The port that the back-end will listen on","destination":{"env":"BACKEND_PORT"}}},"schemaVersion":"v1.0.0","version":"0.1.2"}
+{"credentials":{"hostkey":{"env":"HOST_KEY","path":"/etc/hostkey.txt"}},"custom":{"com.example.backup-preferences":{"frequency":"daily"},"com.example.duffle-bag":{"icon":"https://example.com/icon.png","iconType":"PNG"}},"definitions":{"http_port":{"default":80,"maximum":10240,"minimum":10,"type":"integer"},"port":{"maximum":65535,"minimum":1024,"type":"integer"},"string":{"type":"string"},"x509Certificate":{"contentEncoding":"base64","contentMediaType":"application/x-x509-user-cert","type":"string","writeOnly":true}},"description":"An example 'thin' helloworld Cloud-Native Application Bundle","images":{"my-microservice":{"contentDigest":"sha256:aaaaaaaaaaaa...","description":"my microservice","image":"example/microservice:1.2.3"}},"invocationImages":[{"contentDigest":"sha256:aaaaaaa...","image":"example/helloworld:0.1.0","imageType":"docker"}],"maintainers":[{"email":"matt.butcher@microsoft.com","name":"Matt Butcher","url":"https://example.com"}],"name":"helloworld","outputs":{"clientCert":{"definition":"x509Certificate","path":"/cnab/app/outputs/clientCert"},"hostName":{"applyTo":["install"],"definition":"string","description":"the hostname produced installing the bundle","path":"/cnab/app/outputs/hostname"},"port":{"definition":"port","path":"/cnab/app/outputs/port"}},"parameters":{"backend_port":{"definition":"http_port","description":"The port that the back-end will listen on","destination":{"env":"BACKEND_PORT"}}},"schemaVersion":"v1.0.1","version":"0.1.2"}
 ```
 
 What follows is an example of a thick bundle. Notice how the `invocationImage` and `images` fields reference the underlying docker image manifest (`application/vnd.docker.distribution.manifest.v2+json`), which in turn references the underlying images:
@@ -230,8 +230,8 @@ What follows is an example of a thick bundle. Notice how the `invocationImage` a
          }
       }
    },
-   "schemaVersion":"v1.0.0",
-   "version":"1.0.0"
+   "schemaVersion":"v1.0.1",
+   "version":"1.0.1"
 }
 
 ```
@@ -268,7 +268,7 @@ The schema version must reference the version of the schema used for this docume
 - `CR` indicates that the document references a candidate recommendation. Stability is not assured.
 - No suffix indicates that the document references a release of the specification, and is considered stable.
 
-The current schema version is `v1.0.0`, which is considered stable.
+The current schema version is `v1.0.1`, which is considered stable.
 
 ## Name and Version: Identifying Metadata
 
@@ -927,7 +927,7 @@ A runtime MUST check that it supports any required extensions before performing 
    "requiredExtensions":[ 
       "io.cnab.dependencies"
    ],
-   "schemaVersion":"v1.0.0",
+   "schemaVersion":"v1.0.1",
    "version":"0.1.2"
 }
 ```

--- a/README.md
+++ b/README.md
@@ -4,15 +4,15 @@
 
 Cloud Native Application Bundles (CNAB) are a package format specification that describes a technology for bundling, installing, and managing distributed applications, that are by design, cloud agnostic.
 
-## CNAB Core 1.0 (Final)
+## CNAB Core 1.0.1 (Final)
 
-The CNAB Working Group with the joint approval of the Executive Directors has approved the CNAB Core 1.0 specification for publication. CNAB Core 1.0 is complete.
+The CNAB Working Group with the joint approval of the Executive Directors has approved the CNAB Core 1.0.1 specification for publication. CNAB Core 1.0.1 is complete.
 
 For more information on the approval process, see [the process documentation](901-process.md). Further changes to CNAB Core will be considered for CNAB Core 1.1.
 
 ## Table of Contents
 
-- Chapter 1: [Cloud Native Application Bundle Core 1.0.0 (CNAB1)](100-CNAB.md)
+- Chapter 1: [Cloud Native Application Bundle Core 1.0.1 (CNAB1)](100-CNAB.md)
   1. [The bundle.json File](101-bundle-json.md)
   1. [The Invocation Image Format](102-invocation-image.md)
   1. [The Bundle Runtime](103-bundle-runtime.md)

--- a/examples/101.01-bundle.json
+++ b/examples/101.01-bundle.json
@@ -86,6 +86,6 @@
       }
     }
   },
-  "schemaVersion": "v1.0.0",
+  "schemaVersion": "v1.0.1",
   "version": "0.1.2"
 }

--- a/examples/101.02-bundle.json
+++ b/examples/101.02-bundle.json
@@ -88,6 +88,6 @@
       }
     }
   },
-  "schemaVersion": "v1.0.0",
+  "schemaVersion": "v1.0.1",
   "version": "1.0.0"
 }

--- a/examples/101.03-bundle.json
+++ b/examples/101.03-bundle.json
@@ -100,6 +100,6 @@
   "requiredExtensions": [
     "io.cnab.dependencies"
   ],
-  "schemaVersion": "v1.0.0",
+  "schemaVersion": "v1.0.1",
   "version": "0.1.2"
 }

--- a/examples/400.01-claim.json
+++ b/examples/400.01-claim.json
@@ -10,7 +10,7 @@
     ],
     "name": "technosophos.hellohelm",
     "parameters": {},
-    "schemaVersion": "v1.0.0",
+    "schemaVersion": "v1.0.1",
     "version": "0.1.0"
   },
   "created": "2018-08-30T20:39:55.549002887-06:00",


### PR DESCRIPTION
This PR is the candidate release for CNAB Core 1.0.1

The following people need to vote on ratifying this specification:

@radu-matei
@simonferquel
@technosophos
@jeremyrickard
@silvin-lubecki

The following changes have been included as part of CNAB 1.0.1:

- CNAB Core 1.0.1 da244afe71c1a8ff3ce4e7f5fd1aecaea0fbd885 (Matt Butcher)
- removed unnecessary references to the original authors' registries (#321) 36d7b4817de6902142fc338549c8d93aa94b37a5 (Matt Butcher)
- Update 103-bundle-runtime.md 9b624dc74af9efc3ce05b571379ccc6248f59acc (Matt Butcher)
- Re-added JSON-ish encoding suggestions aae4578835314c769ba57ff143031c572726aa7a (Matt Butcher)
- Minimal changeset for fixing 319 d6c0505c40120a53050c9a7051d761eefe5da294 (Matt Butcher)
- replaced ambiguous description of environment variable content d20292c374ade98fb00c70dc72254c0d6df45b24 (Matt Butcher)
- Update 103-bundle-runtime.md 348e60422e45a576475290f4a245b137f2e3c831 (Ventsislav Potchekanski)
- Bump bundle schemaVersion to 1.0.0 (#278) 5ad8019d1624afb5a0c5a661332a6e133cddac57 (Chris Crone)

Signed-off-by: Matt Butcher <matt.butcher@microsoft.com>