### PR TITLE
Add jlegrone as a maintainer

### DIFF
--- a/OWNERS
+++ b/OWNERS
@@ -4,3 +4,4 @@ maintainers:
 - technosophos
 - jeremyrickard
 - silvin-lubecki
+- jlegrone


### PR DESCRIPTION
I'd like to nominate @jlegrone as a maintainer of the specification. He has made several contributions to the spec (in the form of PRs, issues, and discussion) and he regularly attends the community meetings.