### PR TITLE
Add Carolyn Van Slyck (@carolynvs) as spec maintainer

### DIFF
--- a/OWNERS
+++ b/OWNERS
@@ -5,3 +5,4 @@ maintainers:
 - jeremyrickard
 - silvin-lubecki
 - jlegrone
+- carolynvs


### PR DESCRIPTION
According to the [CNAB general meeting notes from April 29th](https://hackmd.io/TfLYtyRnS8Kfx4ekgLwWLg?both#April-29th---General-Meeting), and as voted by a supermajority of the spec maintainers, this PR adds @carolynvs as a spec maintainer.