### PR TITLE
Remove Simon from the OWNERS file

### DIFF
--- a/OWNERS
+++ b/OWNERS
@@ -1,6 +1,5 @@
 maintainers:
 - radu-matei
-- simonferquel
 - technosophos
 - jeremyrickard
 - silvin-lubecki


### PR DESCRIPTION
@chris-crone pointed out that when we added Silvin as a spec maintainer (#315), we were also supposed to remove Simon from the OWNERS file, since he started working on another project. 

This PR updates the OWNERS file accordingly.