### PR TITLE
chore(*): pin ajv cli to known working version

### DIFF
--- a/Dockerfile.ajv
+++ b/Dockerfile.ajv
@@ -2,4 +2,4 @@ FROM node:8-alpine
 
 RUN apk add --no-cache curl jq
 
-RUN npm install -g ajv-cli
+RUN npm install -g ajv-cli@3.3.0

--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,6 @@
 VERSION       ?= $(shell git describe --tags 2> /dev/null || echo v0)
 BASE_DIR      := $(shell dirname $(realpath $(lastword $(MAKEFILE_LIST))))
-VALIDATOR_IMG := deislabs/cnab-spec.ajv
+VALIDATOR_IMG := cnabio/cnab-spec.ajv
 
 .PHONY: build-validator
 build-validator:
@@ -22,7 +22,7 @@ validate-url: build-validator
 
 .PHONY: build-validator-local
 build-validator-local:
-	@npm install -g ajv-cli
+	@npm install -g ajv-cli@3.3.0
 
 .PHONY: validate-local
 validate-local: build-validator-local


### PR DESCRIPTION
* Pins the ajv cli that we use to validate json to a known working version

It looks like the latest release(s) introduce new flags/usage that we'll need to look into when/if we bump.  (See https://github.com/cnabio/cnab-spec/issues/397)