### PR TITLE
Clarify dependencies custom extension key 

### DIFF
--- a/101-bundle-json.md
+++ b/101-bundle-json.md
@@ -491,7 +491,7 @@ The structure of a `parameters` and `definitions` section looks like the section
       "definitions": {
         "<definition-name>": <json-schema>
       },
-      "dependencies": {
+      "io.cnab.dependencies": {
         "<first-property-name>": <json-schema>,
         "<second-property-name>": [ <string> ]
       },

--- a/500-CNAB-dependencies.md
+++ b/500-CNAB-dependencies.md
@@ -21,8 +21,7 @@ dependency.
 This specification defines [dependencies metadata](#dependencies-metadata) in the
 bundle.json for specifying dependencies but does not dictate that the metadata is
 specifically used at a particular time, or how the dependency graph is resolved.
-Each tool may choose to use the information differently, for example [porter](https://porter.sh) resolves dependencies when the bundle is built, but another tool could
-use this information at runtime.
+Each tool may choose to use the information differently.
 
 There are two cases for how a bundle may need to depend upon another bundle:
 

--- a/500-CNAB-dependencies.md
+++ b/500-CNAB-dependencies.md
@@ -37,7 +37,7 @@ stored in the custom extensions section of the bundle.
 ```json
 {
   "custom": {
-    "dependencies": {
+    "io.cnab.dependencies": {
       "sequence": ["storage", "mysql"],
       "requires": {
         "storage": {
@@ -62,10 +62,10 @@ This section is a placeholder and will be completed in a follow-up pull request.
 
 ## Dependencies Metadata
 
-This specification introduces a `dependencies` object in the bundle.json
+This specification introduces a `io.cnab.dependencies` custom extension in the bundle.json
 that defines metadata necessary to specify a dependency.
 
-The entry `dependencies` in the custom extension object, `custom`, is reserved and
+The entry `io.cnab.dependencies` in the custom extension object, `custom`, is reserved and
 MUST only be used for this CNAB Dependencies Specification.
 
 ### sequence

--- a/810-well-known-custom-extensions.md
+++ b/810-well-known-custom-extensions.md
@@ -11,7 +11,9 @@ A bundle indicates that it uses a custom extension by including them in its cust
 
 ## Dependencies
 
-See the [Dependencies Specification](500-CNAB-dependencies.md).
+A custom bundle extension, `io.cnab.dependencies`, MAY be defined that specifies
+that the bundle depends up on other bundles. See the [Dependencies
+Specification](500-CNAB-dependencies.md) for details.
 
 ## Parameter Sources
 


### PR DESCRIPTION
* The dependendencies custom extension was sometimes specified with its full key `io.cnab.dependencies` and in other places used its shorthand `dependencies`. I've updated the spec to be clear that the key to use is the full `io.cnab.dependencies`.
* Remove outdated info on Porter's dep resolution

Fixes #403 