### PR TITLE
Add applyTo to Credentials

### DIFF
--- a/101-bundle-json.md
+++ b/101-bundle-json.md
@@ -147,7 +147,8 @@ What follows is an example of a thick bundle. Notice how the `invocationImage` a
          "path":"/etc/hostkey.txt"
       },
       "image_token":{
-         "env":"AZ_IMAGE_TOKEN"
+         "env":"AZ_IMAGE_TOKEN", 
+         "applyTo": ["install"]
       },
       "kubeconfig":{
          "path":"/home/.kube/config"
@@ -701,7 +702,8 @@ What about parameters such as database passwords used by the application? Proper
     },
     "image_token": {
       "env": "AZ_IMAGE_TOKEN",
-      "required": true
+      "required": true,
+      "applyTo": ["install"]
     },
     "kubeconfig": {
       "path": "/home/.kube/config"
@@ -712,6 +714,7 @@ What about parameters such as database passwords used by the application? Proper
 
 - The `credentials` container is a map of human-friendly credential names to a description of where the invocation image expects to find them.
   - The name key MUST be human-readable
+    - `applyTo`: restricts this credential to a given list of actions. If empty or missing, applies to all actions (OPTIONAL).
     - `path` describes the _absolute path within the invocation image_ where the invocation image expects to find the credential. Specified path MUST NOT be a subpath of `/cnab/app/outputs`.
     - `env` contains _the name of an environment variable_ that the invocation image expects to have available when executing the CNAB `run` tool (covered in the next section).
     - `description` contains a user-friendly description of the credential.

--- a/examples/101.02-bundle.json
+++ b/examples/101.02-bundle.json
@@ -5,7 +5,8 @@
       "path": "/etc/hostkey.txt"
     },
     "image_token": {
-      "env": "AZ_IMAGE_TOKEN"
+      "env": "AZ_IMAGE_TOKEN",
+      "applyTo": ["install"]
     },
     "kubeconfig": {
       "path": "/home/.kube/config"

--- a/schema/bundle.schema.json
+++ b/schema/bundle.schema.json
@@ -10,6 +10,13 @@
           "description": "A user-friendly description of this credential",
           "type": "string"
         },
+        "applyTo": {
+          "description": "An optional exhaustive list of actions handling this credential",
+          "items": {
+            "type": "string"
+          },
+          "type": "array"
+        },
         "env": {
           "description": "The environment variable name, such as MY_VALUE, into which the credential will be placed",
           "type": "string"


### PR DESCRIPTION
Allow restricting a credential to a list of actions, just like Parameters can do today. This allows a credential to not have to be
passed in for actions that do not use it. 

Closes #366 