### PR TITLE
Prepare for Core 1.2.0 release

### DIFF
--- a/000-index.md
+++ b/000-index.md
@@ -5,7 +5,7 @@ weight: 001
 
 # CNAB Specifications
 
-1. [Cloud Native Application Bundle Core 1.1.0 (CNAB1)](100-CNAB.md)
+1. [Cloud Native Application Bundle Core 1.2.0 (CNAB1)](100-CNAB.md)
     - [The bundle.json File](101-bundle-json.md)
     - [The Invocation Image Format](102-invocation-image.md)
     - [The Bundle Runtime](103-bundle-runtime.md)

--- a/100-CNAB.md
+++ b/100-CNAB.md
@@ -3,8 +3,8 @@ title: CNAB Core
 weight: 100
 ---
 
-# Cloud Native Application Bundle Core 1.1.0 (CNAB1)
-*[Final Approval, Published](901-process.md), Sept. 2019*
+# Cloud Native Application Bundle Core 1.2.0 (CNAB1)
+*[Final Approval, Published](901-process.md), May 2021*
 
 
 The Cloud Native Application Bundle (CNAB) is a _standard packaging format_ for multi-component distributed applications. It allows packages to target different runtimes and architectures. It empowers application distributors to package applications for deployment on a wide variety of cloud platforms, providers, and services. Furthermore, it provides necessary capabilities for delivering multi-container applications in disconnected (airgapped) environments.

--- a/101-bundle-json.md
+++ b/101-bundle-json.md
@@ -13,7 +13,7 @@ The `bundle.json` file is a representation of bundle metadata. It MUST be repres
 
 A `bundle.json` is broken down into the following categories of information:
 
-- The schema version of the bundle, as a string with a `v` prefix. This schema is to be referenced as `v1` or `v1.1.0`
+- The schema version of the bundle, as a string with a `v` prefix. This schema is to be referenced as `v1` or `v1.2.0`
 - The top-level package information (`name` and `version`)
   - `name`: The bundle name, including namespacing. The namespace can have one or more elements separated by a dot (e.g. `acme.tunnels.wordpress`). The left most element of the namespace is the most general moving toward more specific elements on the right.
   - `version`: Semantic version of the bundle
@@ -123,7 +123,7 @@ The following is an example of a `bundle.json` for a bundled distributed as a _t
          }
       }
    },
-   "schemaVersion":"v1.1.0",
+   "schemaVersion":"v1.2.0",
    "version":"0.1.2"
 }
 ```
@@ -134,7 +134,7 @@ The canonical JSON version of the above is:
 
 <!-- prettier-ignore -->
 ```json
-{"credentials":{"hostkey":{"env":"HOST_KEY","path":"/etc/hostkey.txt"}},"custom":{"com.example.backup-preferences":{"frequency":"daily"},"com.example.duffle-bag":{"icon":"https://example.com/icon.png","iconType":"PNG"}},"definitions":{"http_port":{"default":80,"maximum":10240,"minimum":10,"type":"integer"},"port":{"maximum":65535,"minimum":1024,"type":"integer"},"string":{"type":"string"},"x509Certificate":{"contentEncoding":"base64","contentMediaType":"application/x-x509-user-cert","type":"string","writeOnly":true}},"description":"An example 'thin' helloworld Cloud-Native Application Bundle","images":{"my-microservice":{"contentDigest":"sha256:aaaaaaaaaaaa...","description":"my microservice","image":"example/microservice:1.2.3"}},"invocationImages":[{"contentDigest":"sha256:aaaaaaa...","image":"example/helloworld:0.1.0","imageType":"docker"}],"maintainers":[{"email":"matt.butcher@microsoft.com","name":"Matt Butcher","url":"https://example.com"}],"name":"helloworld","outputs":{"clientCert":{"definition":"x509Certificate","path":"/cnab/app/outputs/clientCert"},"hostName":{"applyTo":["install"],"definition":"string","description":"the hostname produced installing the bundle","path":"/cnab/app/outputs/hostname"},"port":{"definition":"port","path":"/cnab/app/outputs/port"}},"parameters":{"backend_port":{"definition":"http_port","description":"The port that the back-end will listen on","destination":{"env":"BACKEND_PORT"}}},"schemaVersion":"v1.1.0","version":"0.1.2"}
+{"credentials":{"hostkey":{"env":"HOST_KEY","path":"/etc/hostkey.txt"}},"custom":{"com.example.backup-preferences":{"frequency":"daily"},"com.example.duffle-bag":{"icon":"https://example.com/icon.png","iconType":"PNG"}},"definitions":{"http_port":{"default":80,"maximum":10240,"minimum":10,"type":"integer"},"port":{"maximum":65535,"minimum":1024,"type":"integer"},"string":{"type":"string"},"x509Certificate":{"contentEncoding":"base64","contentMediaType":"application/x-x509-user-cert","type":"string","writeOnly":true}},"description":"An example 'thin' helloworld Cloud-Native Application Bundle","images":{"my-microservice":{"contentDigest":"sha256:aaaaaaaaaaaa...","description":"my microservice","image":"example/microservice:1.2.3"}},"invocationImages":[{"contentDigest":"sha256:aaaaaaa...","image":"example/helloworld:0.1.0","imageType":"docker"}],"maintainers":[{"email":"matt.butcher@microsoft.com","name":"Matt Butcher","url":"https://example.com"}],"name":"helloworld","outputs":{"clientCert":{"definition":"x509Certificate","path":"/cnab/app/outputs/clientCert"},"hostName":{"applyTo":["install"],"definition":"string","description":"the hostname produced installing the bundle","path":"/cnab/app/outputs/hostname"},"port":{"definition":"port","path":"/cnab/app/outputs/port"}},"parameters":{"backend_port":{"definition":"http_port","description":"The port that the back-end will listen on","destination":{"env":"BACKEND_PORT"}}},"schemaVersion":"v1.2.0","version":"0.1.2"}
 ```
 
 What follows is an example of a thick bundle. Notice how the `invocationImage` and `images` fields reference the underlying docker image manifest (`application/vnd.docker.distribution.manifest.v2+json`), which in turn references the underlying images:
@@ -231,7 +231,7 @@ What follows is an example of a thick bundle. Notice how the `invocationImage` a
          }
       }
    },
-   "schemaVersion":"v1.1.0",
+   "schemaVersion":"v1.2.0",
    "version":"1.0.0"
 }
 
@@ -269,7 +269,7 @@ The schema version must reference the version of the schema used for this docume
 - `CR` indicates that the document references a candidate recommendation. Stability is not assured.
 - No suffix indicates that the document references a release of the specification, and is considered stable.
 
-The current schema version is `v1.1.0`, which is considered stable.
+The current schema version is `v1.2.0`, which is considered stable.
 
 ## Name and Version: Identifying Metadata
 
@@ -940,7 +940,7 @@ A runtime MUST check that it supports any required extensions before performing 
    "requiredExtensions":[
       "io.cnab.dependencies"
    ],
-   "schemaVersion":"v1.1.0",
+   "schemaVersion":"v1.2.0",
    "version":"0.1.2"
 }
 ```

--- a/README.md
+++ b/README.md
@@ -4,15 +4,16 @@
 
 Cloud Native Application Bundles (CNAB) are a package format specification that describes a technology for bundling, installing, and managing distributed applications, that are by design, cloud agnostic.
 
-## CNAB Core 1.1.0 (Final)
+## CNAB Core 1.2.0 (Final)
 
-The CNAB Working Group with the joint approval of the Executive Directors has approved the CNAB Core 1.1.0 specification for publication. CNAB Core 1.1.0 is complete.
+The CNAB Working Group with the joint approval of the Executive Directors has approved the CNAB Core 1.2.0 specification for publication. CNAB Core 1.2.0 is complete.
 
-For more information on the approval process, see [the process documentation](901-process.md). Further changes to CNAB Core will be considered for CNAB Core 1.2.
+For more information on the approval process, see [the process documentation](901-process.md). Further changes to CNAB Core will be considered for CNAB Core 1.3.
 
 ### Branch/Tag Structure
 
 - [main](https://github.com/cnabio/cnab-spec) is the current working draft of all specs
+- [cnab-core-1.2.0](https://github.com/cnabio/cnab-spec/tree/cnab-core-1.2.0) is the CNAB Core 1.2.0 final draft
 - [cnab-core-1.1.0](https://github.com/cnabio/cnab-spec/tree/cnab-core-1.1.0) is the CNAB Core 1.1.0 final draft
 - [cnab-core-1.0.1](https://github.com/cnabio/cnab-spec/tree/cnab-core-1.0.1) is the CNAB Core 1.0.1 final draft
 - [cnab-core-1.0](https://github.com/cnabio/cnab-spec/tree/cnab-core-1.0) is the CNAB Core 1.0.0 final draft


### PR DESCRIPTION
This minor release includes the following changes to the Core spec:

* Add applyTo to the Credentials subdocument of bundle.json (#407)
* Allow numbers again in the canonical json representations of bundle.json (#414)
