### PR TITLE
Add CODEOWNERS file

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,7 @@
+# See the CODEOWNERS syntax at https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/customizing-your-repository/about-code-owners#codeowners-syntax
+
+# These owners will be the default owners for everything in
+# the repo. Unless a later match takes precedence,
+# @global-owner1 and @global-owner2 will be requested for
+# review when someone opens a pull request.
+*       @radu-matei @technosophos @jeremyrickard @silvin-lubecki @jlegrone @carolynvs


### PR DESCRIPTION
This adds a GitHub CODEOWNERS file so that when someone opens a PR, reviewers are automatically assigned.

I have populated it with the people designated in our OWNERS file.